### PR TITLE
fix: wave bar solid/outline glyph consistency

### DIFF
--- a/statusline-command.sh
+++ b/statusline-command.sh
@@ -216,19 +216,14 @@ progress_bar() {
         if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x97\x8f" "$cfill"           # ●
         else printf "%b\xe2\x97\x8b" "$C_HEX_EMPTY"; fi ;;                          # ○
       wave)
-        # 4-phase scroll using 4 distinct glyphs: ▲ ▼ △ ▽ (solid/outline up/down triangles).
-        # wave_shift (global, 0-3) advances the pattern one position left every 2s.
-        # Each of the 4 positions produces a visually distinct bar pattern.
+        # 2-phase alternation (up/down), 4-step scroll via wave_shift.
+        # Filled cells always solid (▲▼); empty cells always outline (△▽).
         local wpos=$(( (i + wave_shift) % 4 ))
         case "$wpos" in
-          0) if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\xb2" "$cfill"      # ▲ solid up
-             else printf "%b\xe2\x96\xb2" "$C_HEX_EMPTY"; fi ;;                    # ▲ solid up, dim
-          1) if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\xbc" "$cfill"      # ▼ solid down
-             else printf "%b\xe2\x96\xbc" "$C_HEX_EMPTY"; fi ;;                    # ▼ solid down, dim
-          2) if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\xb3" "$cfill"      # △ outline up
-             else printf "%b\xe2\x96\xb3" "$C_HEX_EMPTY"; fi ;;                    # △ outline up, dim
-          3) if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\xbd" "$cfill"      # ▽ outline down
-             else printf "%b\xe2\x96\xbd" "$C_HEX_EMPTY"; fi ;;                    # ▽ outline down, dim
+          0|2) if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\xb2" "$cfill"   # ▲ solid up
+               else printf "%b\xe2\x96\xb3" "$C_HEX_EMPTY"; fi ;;                  # △ outline up, dim
+          1|3) if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\xbc" "$cfill"   # ▼ solid down
+               else printf "%b\xe2\x96\xbd" "$C_HEX_EMPTY"; fi ;;                  # ▽ outline down, dim
         esac ;;
       block)
         if [ "$i" -lt "$filled" ]; then printf "%s\xe2\x96\x88" "$cfill"           # █


### PR DESCRIPTION
## Summary
- Filled bar cells always emit solid triangles (▲▼); empty cells always emit outline triangles (△▽)
- Fixes positions 2 and 3 which were incorrectly using outline glyphs for both filled and empty states
- 4-step `wave_shift` scroll and up/down alternation preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)